### PR TITLE
Add build job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/not_main.yml
+++ b/.github/workflows/not_main.yml
@@ -1,4 +1,4 @@
-name: Linter
+name: Linter and Build Workflow
 
 on:
   push:

--- a/.github/workflows/not_main.yml
+++ b/.github/workflows/not_main.yml
@@ -21,3 +21,16 @@ jobs:
         run: npm ci
       - name: Run linter
         run: npm run lint
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build


### PR DESCRIPTION
This pull request adds a new `build` job to the `.github/workflows/not_main.yml` file. The `build` job is set to run after the `lint` job and includes steps for checking out the repository, setting up Node.js, installing dependencies, and building the project. 

Workflow enhancements:

* [`.github/workflows/not_main.yml`](diffhunk://#diff-1ef225f2b85a64bdf355afae83da3388a8ac5afe8a594af39be2e08f84f7aacbR24-R36): Added a `build` job that runs on `ubuntu-latest`, depends on the `lint` job, and includes steps for repository checkout, Node.js setup, dependency installation, and project build.