### PR TITLE
Add Excel export functionality to PendingToPayPage and include xlsx d…

### DIFF
--- a/app/finance/pending-to-pay/page.tsx
+++ b/app/finance/pending-to-pay/page.tsx
@@ -53,8 +53,7 @@ export default function PendingToPayPage() {
 
   const getPendingsExcel = async () => {
     const sheetName = "Pending to pay";
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const content = pendingToPay.map((item: any) => ({
+    const content = pendingToPay.map((item: PendingToPayItem) => ({
       OrderId: item.OrderId,
       Product: item.Product,
       Status: item.Status,

--- a/app/finance/pending-to-pay/page.tsx
+++ b/app/finance/pending-to-pay/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { FaFileExcel, FaSearch, FaEye, FaTimes, FaRegCheckCircle, FaPlus } from "react-icons/fa";
 import styles from "@/app/finance/page.module.css";
 import { useRouter } from "next/navigation";
+import toExcel from "@/lib/xlsx/toExcel";
 
 export default function PendingToPayPage() {
   const router = useRouter();
@@ -49,6 +50,34 @@ export default function PendingToPayPage() {
         console.error("Error fetching pending to pay data:", error);
       });
   }, []);
+
+  const getPendingsExcel = async () => {
+    const sheetName = "Pending to pay";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const content = pendingToPay.map((item: any) => ({
+      OrderId: item.OrderId,
+      Product: item.Product,
+      Status: item.Status,
+      DueDate: item.DueDate,
+      PayDate: item.PayDate,
+    }));
+
+    const columns = [
+      { label: "Order Id", value: "OrderId" },
+      { label: "Product", value: "Product" },
+      { label: "Status", value: "Status" },
+      { label: "Due Date", value: "DueDate" },
+      { label: "Pay Date", value: "PayDate" },
+    ];
+
+    try {
+      toExcel(sheetName, columns, content);
+      alert("Excel file created successfully");
+    } catch (error) {
+      console.error("Error creating Excel file:", error);
+      alert("Failed to create Excel file");
+    }
+  };
 
   const handleView = (id: string) => {
     router.push(`/finance/pending-to-pay/${id}`);
@@ -112,7 +141,7 @@ export default function PendingToPayPage() {
                 </div>
               }
               className="bg-[#a01217] text-white hover:bg-[#8b0f14] transition-colors p-2 w-fit h-fit"
-              onClick={() => alert("Excel")}
+              onClick={getPendingsExcel}
             />
           </div>
         </div>

--- a/app/finance/pending-to-pay/page.tsx
+++ b/app/finance/pending-to-pay/page.tsx
@@ -71,7 +71,7 @@ export default function PendingToPayPage() {
     ];
 
     try {
-      toExcel(sheetName, columns, content);
+      await toExcel(sheetName, columns, content);
       alert("Excel file created successfully");
     } catch (error) {
       console.error("Error creating Excel file:", error);

--- a/app/finance/pending-to-pay/page.tsx
+++ b/app/finance/pending-to-pay/page.tsx
@@ -15,6 +15,15 @@ export default function PendingToPayPage() {
   const [description, setDescription] = useState("");
   const [pendingToPay, setPendingToPay] = useState([]);
 
+  type PendingToPayItem = {
+    id: string;
+    OrderId: string;
+    Product: string;
+    Status: string;
+    DueDate: string;
+    PayDate: string;
+  };
+
   const warehouseOptions = [
     { label: "Pending", value: "pending" },
     { label: "Paid", value: "paid" },

--- a/lib/xlsx/toExcel.ts
+++ b/lib/xlsx/toExcel.ts
@@ -1,0 +1,16 @@
+import xlsx from "json-as-xlsx";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function downloadFile(sheetName: string, columns: any[], content: any[]) {
+  const data = [
+    {
+      sheet: sheetName,
+      columns: columns,
+      content: content,
+    },
+  ];
+  const settings = {
+    fileName: sheetName,
+  };
+  return xlsx(data, settings);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/postcss": "^4.1.8",
         "cookie": "^1.0.2",
         "date-fns": "^4.1.0",
+        "json-as-xlsx": "^2.5.6",
         "jsonwebtoken": "^9.0.2",
         "next": "15.3.2",
         "postcss": "^8.5.4",
@@ -56,6 +57,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@e965/xlsx": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@e965/xlsx/-/xlsx-0.20.3.tgz",
+      "integrity": "sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1608,9 +1621,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2238,9 +2251,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4214,6 +4227,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-as-xlsx": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/json-as-xlsx/-/json-as-xlsx-2.5.6.tgz",
+      "integrity": "sha512-z7phlB+VgS9wZv2N4SBKlguC3C7uauSj2PYSZICCrPaiu1lu8zkCpzZ4sOHWi0/3Je0CJl87q+J+3mpZbxpOew==",
+      "license": "MIT",
+      "dependencies": {
+        "@e965/xlsx": "^0.20.0"
       }
     },
     "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/postcss": "^4.1.8",
     "cookie": "^1.0.2",
     "date-fns": "^4.1.0",
+    "json-as-xlsx": "^2.5.6",
     "jsonwebtoken": "^9.0.2",
     "next": "15.3.2",
     "postcss": "^8.5.4",


### PR DESCRIPTION
This pull request introduces functionality to export "Pending to Pay" data as an Excel file in the `PendingToPayPage` component. It includes the addition of a utility function for generating Excel files and updates to the UI to integrate this feature.

### Feature: Export to Excel

* **Added Excel export utility**: Introduced a new `toExcel` function in `lib/xlsx/toExcel.ts` using the `json-as-xlsx` library to generate and download Excel files.
* **Integrated export functionality in `PendingToPayPage`**: Added a `getPendingsExcel` function to map and format the "Pending to Pay" data into an Excel file and handle the file creation process.
* **Updated button behavior**: Modified the Excel button's `onClick` handler to trigger the `getPendingsExcel` function instead of showing an alert.

### Dependency Updates

* **Added `json-as-xlsx` library**: Included the `json-as-xlsx` library in `package.json` to enable Excel file generation.

### Codebase Enhancements

* **Imported `toExcel` utility**: Added an import statement for the `toExcel` utility in `app/finance/pending-to-pay/page.tsx`